### PR TITLE
Missing requirement: Add gunicorn as dependency (for web server)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ google-crc32c==1.1.2
 google-resumable-media==1.2.0
 googleapis-common-protos==1.52.0
 grpcio==1.35.0
+gunicorn==20.0.4
 httplib2==0.18.1
 idna==2.10
 isort==5.7.0


### PR DESCRIPTION
After reading `bash: gunicorn: command not found` on the Heroku logs, this makes more sense.